### PR TITLE
add no ui setting

### DIFF
--- a/AutoScreenShot/AutoScreenShotController.cs
+++ b/AutoScreenShot/AutoScreenShotController.cs
@@ -149,6 +149,7 @@ namespace AutoScreenShot
         private float _posScale;
         private ImageExtention _saveType;
         private static readonly int[] aaNums = { 1, 2, 4, 8 };
+        private const int UI_LAYER = 5;
         #endregion
         //ﾟ+｡*ﾟ+｡｡+ﾟ*｡+ﾟ ﾟ+｡*ﾟ+｡｡+ﾟ*｡+ﾟ ﾟ+｡*ﾟ+｡*ﾟ+｡｡+ﾟ*｡+ﾟ ﾟ+｡*ﾟ+｡｡+ﾟ*｡+ﾟ ﾟ+｡*ﾟ+｡*ﾟ+｡｡+ﾟ*｡+ﾟ ﾟ+｡*ﾟ+｡｡+ﾟ*｡+ﾟ ﾟ+｡*
         #region // 構築・破棄
@@ -172,6 +173,9 @@ namespace AutoScreenShot
             this._ssCamera.stereoTargetEye = StereoTargetEyeMask.None;
             this._ssCamera.gameObject.transform.position = new Vector3(0f, 1.7f, -3.2f);
             this._ssCamera.cullingMask = -1;
+            if (PluginConfig.Instance.NoUI) {
+                this._ssCamera.cullingMask &= ~(1 << UI_LAYER);
+            }
             Plugin.Log.Debug($"{this._ssCamera.depthTextureMode}");
             this._ssCamera.depthTextureMode = (DepthTextureMode.Depth | DepthTextureMode.DepthNormals | DepthTextureMode.MotionVectors);
 

--- a/AutoScreenShot/Configuration/PluginConfig.cs
+++ b/AutoScreenShot/Configuration/PluginConfig.cs
@@ -13,6 +13,7 @@ namespace AutoScreenShot.Configuration
     {
         public static PluginConfig Instance { get; set; }
         public virtual bool Enable { get; set; } = true;
+        public virtual bool NoUI { get; set; } = false;
         public virtual int MinSec { get; set; } = 6;
         public virtual int MaxSec { get; set; } = 120;
         public virtual int PositionScale { get; set; } = 10;

--- a/AutoScreenShot/Views/SettingViewController.bsml
+++ b/AutoScreenShot/Views/SettingViewController.bsml
@@ -1,6 +1,7 @@
 ﻿<bg xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='https://monkeymanboy.github.io/BSML-Docs/ https://raw.githubusercontent.com/monkeymanboy/BSML-Docs/gh-pages/BSMLSchema.xsd'>
   <settings-container>
     <toggle-setting text='Enable' value='enable'></toggle-setting>
+    <toggle-setting text='No UI' value='no-ui'></toggle-setting>
     <toggle-setting text='Show in menu' value='show-in-menu'></toggle-setting>
     <slider-setting text='Picture count' value ='pictuer-count' integer-only='true' min='-1' max='500' hover-hint='-1 = unlimited'></slider-setting>
     <slider-setting text='Min FoV' value ='min-fov' increment='0.5' min='0.5' max='200.0'></slider-setting>

--- a/AutoScreenShot/Views/SettingViewController.cs
+++ b/AutoScreenShot/Views/SettingViewController.cs
@@ -17,6 +17,7 @@ namespace AutoScreenShot.Views
         public void Initialize()
         {
             this.Enable = PluginConfig.Instance.Enable;
+            this.NoUI = PluginConfig.Instance.NoUI;
             this.ShowInMenu = PluginConfig.Instance.ShowPictureInMenu;
             this.MinFov = PluginConfig.Instance.MinFoV;
             this.MaxFov = PluginConfig.Instance.MaxFoV;
@@ -30,6 +31,7 @@ namespace AutoScreenShot.Views
         private void OnConfigChanged(PluginConfig obj)
         {
             this.Enable = obj.Enable;
+            this.NoUI = obj.NoUI;
             this.ShowInMenu = obj.ShowPictureInMenu;
             this.MinFov = obj.MinFoV;
             this.MaxFov = obj.MaxFoV;
@@ -52,6 +54,9 @@ namespace AutoScreenShot.Views
             this.NotifyPropertyChanged(e);
             if (e == nameof(this.Enable)) {
                 PluginConfig.Instance.Enable = this.Enable;
+            }
+            else if (e == nameof(this.NoUI)) {
+                PluginConfig.Instance.NoUI = this.NoUI;
             }
             else if (e == nameof(this.ShowInMenu)) {
                 PluginConfig.Instance.ShowPictureInMenu = this.ShowInMenu;
@@ -77,6 +82,18 @@ namespace AutoScreenShot.Views
             get => this.enable_;
 
             set => this.SetProperty(ref this.enable_, value);
+        }
+
+
+        /// <summary>UIを非表示にするか を取得、設定</summary>
+        private bool noUI_;
+        [UIValue("no-ui")]
+        /// <summary>UIを非表示にするか を取得、設定</summary>
+        public bool NoUI
+        {
+            get => this.noUI_;
+
+            set => this.SetProperty(ref this.noUI_, value);
         }
 
 


### PR DESCRIPTION
ScreenShotにスコアやチャット等が映り込むのを避けるため、UIレイヤーを非表示にできるようにしました。
- 設定項目に `No UI` を追加
- `No UI` が true の場合、UIレイヤーが非表示の状態でScreenShotを取得するようにマスクを設定