### PR TITLE
スクリーンショットの読み取りを分割して負荷分散するように変更

### DIFF
--- a/AutoScreenShot/Configuration/PluginConfig.cs
+++ b/AutoScreenShot/Configuration/PluginConfig.cs
@@ -32,6 +32,7 @@ namespace AutoScreenShot.Configuration
         [UseConverter(typeof(Vector2Converter))]
         public virtual Vector2 PictuerRenderSize { get; set; } = new Vector2(1920, 1080);
         public virtual int AntiAliasing { get; set; } = 1;
+        public virtual int ReadSplit { get; set; } = 4;
 
         public event Action<PluginConfig> OnConfigChanged;
         /// <summary>


### PR DESCRIPTION
AsyncGPUReadbackですが、非同期でもかなり処理が重いようで、2K画像でも譜面や環境によって稀にプチフリになったりするようです。4K解像度の場合、i7-14700K RTX4070 Ti SUPERでもプチプリします。
そのため、オプションにReadSplitを設けてデフォルトで4分割して読み込むようにしてみました。

また、レンダリングはRender()を呼び出さないで通常のレンダリングをさせて、次のフレームで読み込むようにしました。
VRIKはLateUpdateでアバターのボーン変更しているので、セイバーとアバターの表示ズレが解消されると思います。

下記は本pull request適用前後での負荷状況です
環境:i9-9900K GTX1080 Quest2 BeatSaber1.29.1 mod:最小環境 BSIPA, SiraUtil, BSML, AutoScreenShot

**2K解像度**
AutoScreenShot-1.3.0  解像度:1920x1080
![10_org_2k](https://github.com/denpadokei/AutoScreenShot/assets/14249877/1eeb3d33-13e4-4b67-b7fa-cd94b60ef2e3)
AutoScreenShot-1.3.0+本pull request  解像度:1920x1080 ReadSplit=4
![10_new_2k](https://github.com/denpadokei/AutoScreenShot/assets/14249877/6ded4c30-f5cf-45b7-9ed2-e1b06344cb43)

**4K解像度**
AutoScreenShot-1.3.0  解像度:3840x2160
![10_org_4k](https://github.com/denpadokei/AutoScreenShot/assets/14249877/5626719a-73b9-43b2-b369-62f4cc494353)
AutoScreenShot-1.3.0+本pull request  解像度:3840x2160 ReadSplit=16
![10_new_4k](https://github.com/denpadokei/AutoScreenShot/assets/14249877/b686dce2-4f64-4126-baa3-e18e51842c48)
